### PR TITLE
Improve Matrix transport database directory creation handling

### DIFF
--- a/src/Transport/MatrixTransportFactory.php
+++ b/src/Transport/MatrixTransportFactory.php
@@ -67,8 +67,9 @@ final class MatrixTransportFactory extends AbstractTransportFactory
             throw new MatrixException("The access token must be provided either as part of DSN or as a configuration parameter.");
         }
 
-        if (!is_dir(dirname($this->databasePath))) {
-            mkdir(dirname($this->databasePath), 0777, true);
+        $databaseDirectory = dirname($this->databasePath);
+        if (!is_dir($databaseDirectory) && !@mkdir($databaseDirectory, 0777, true) && !is_dir($databaseDirectory)) {
+            throw new MatrixException(sprintf('Failed to create the database directory "%s".', $databaseDirectory));
         }
 
         return new MatrixTransport(


### PR DESCRIPTION
## Summary
- guard matrix transport factory against failures when creating the database directory
- raise a clear exception if the directory cannot be created instead of silently failing

## Testing
- `composer install --ignore-platform-req=ext-ffi`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68d5c166137c832ea04697615a64c4e7