### PR TITLE
Add PHPUnit coverage for Matrix transport

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
   },
   "require-dev": {
     "symfony/matrix-notifier": "^7.3",
-    "phpunit/phpunit": "^12.3"
+    "phpunit/phpunit": "^12.3",
+    "dg/bypass-finals": "^1.9"
   },
   "autoload-dev": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0c8b9de5b0407e01d895ec62b07ef4ce",
+    "content-hash": "506e3a85602b25d3ca756e1cb0b40a31",
     "packages": [
         {
             "name": "psr/container",
@@ -1918,6 +1918,59 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "dg/bypass-finals",
+            "version": "v1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dg/bypass-finals.git",
+                "reference": "920a7da2f3c1422fd83f9ec4df007af53dc4018b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dg/bypass-finals/zipball/920a7da2f3c1422fd83f9ec4df007af53dc4018b",
+                "reference": "920a7da2f3c1422fd83f9ec4df007af53dc4018b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "nette/tester": "^2.3",
+                "phpstan/phpstan": "^0.12"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                }
+            ],
+            "description": "Removes final keyword from source code on-the-fly and allows mocking of final methods and classes",
+            "keywords": [
+                "finals",
+                "mocking",
+                "phpunit",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "issues": "https://github.com/dg/bypass-finals/issues",
+                "source": "https://github.com/dg/bypass-finals/tree/v1.9.0"
+            },
+            "time": "2025-01-16T00:46:05+00:00"
+        },
         {
             "name": "myclabs/deep-copy",
             "version": "1.13.4",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.3/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          colors="true"
 >
     <testsuites>

--- a/tests/Options/MatrixOptionsTest.php
+++ b/tests/Options/MatrixOptionsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rikudou\MatrixNotifier\Tests\Options;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Rikudou\MatrixNotifier\Enum\MessageType;
+use Rikudou\MatrixNotifier\Enum\RenderingType;
+use Rikudou\MatrixNotifier\Options\MatrixOptions;
+
+#[CoversClass(MatrixOptions::class)]
+final class MatrixOptionsTest extends TestCase
+{
+    public function testToArrayContainsAllValues(): void
+    {
+        $options = new MatrixOptions(
+            recipientId: '@john:example.com',
+            messageType: MessageType::Notice,
+            renderingType: RenderingType::Markdown,
+        );
+
+        $this->assertSame(
+            [
+                'recipientId' => '@john:example.com',
+                'messageType' => MessageType::Notice->value,
+                'renderingType' => RenderingType::Markdown->value,
+            ],
+            $options->toArray(),
+        );
+    }
+
+    public function testGetRecipientIdReturnsConfiguredValue(): void
+    {
+        $options = new MatrixOptions(recipientId: '@alice:example.com');
+
+        $this->assertSame('@alice:example.com', $options->getRecipientId());
+    }
+}

--- a/tests/Transport/MatrixTransportFactoryTest.php
+++ b/tests/Transport/MatrixTransportFactoryTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rikudou\MatrixNotifier\Tests\Transport;
+
+use LogicException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Rikudou\MatrixNotifier\Bridge\BridgeMessage;
+use Rikudou\MatrixNotifier\Bridge\GolangLibBridge;
+use Rikudou\MatrixNotifier\Enum\MessageType;
+use Rikudou\MatrixNotifier\Enum\RenderingType;
+use Rikudou\MatrixNotifier\Exception\MatrixException;
+use Rikudou\MatrixNotifier\Options\MatrixOptions;
+use Rikudou\MatrixNotifier\Transport\MatrixTransport;
+use Rikudou\MatrixNotifier\Transport\MatrixTransportFactory;
+use Symfony\Component\Notifier\Transport\Dsn;
+use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
+use Symfony\Component\Notifier\Message\ChatMessage;
+
+#[CoversClass(MatrixTransportFactory::class)]
+final class MatrixTransportFactoryTest extends TestCase
+{
+    public function testCreateReturnsConfiguredTransport(): void
+    {
+        $bridge = $this->createMock(GolangLibBridge::class);
+
+        $factory = new MatrixTransportFactory(
+            pickleKey: 'pickle',
+            deviceId: 'DEVICE',
+            accessToken: 'config-token',
+            recoveryKey: 'recovery',
+            defaultRecipient: '@default:example.com',
+            databaseDsn: 'sqlite:///var/matrix.db',
+            bridge: $bridge,
+        );
+
+        $dsn = new Dsn('smatrix://matrix.example.com:8448?accessToken=dsn-token');
+        $transport = $factory->create($dsn);
+
+        $this->assertInstanceOf(MatrixTransport::class, $transport);
+        $this->assertSame('matrix://matrix.example.com:8448', (string) $transport);
+    }
+
+    public function testCreateUsesConfiguredAccessTokenWhenMissingFromDsn(): void
+    {
+        $bridge = $this->createMock(GolangLibBridge::class);
+        $bridge->expects($this->once())
+            ->method('send')
+            ->with($this->callback(function (BridgeMessage $message): bool {
+                $this->assertSame('config-token', $message->accessToken);
+                $this->assertSame(MessageType::TextMessage, $message->messageType);
+                $this->assertSame(RenderingType::PlainText, $message->renderingType);
+
+                return true;
+            }))
+            ->willReturn('bridge-result');
+
+        $factory = new MatrixTransportFactory(
+            pickleKey: 'pickle',
+            deviceId: 'DEVICE',
+            accessToken: 'config-token',
+            recoveryKey: 'recovery',
+            defaultRecipient: '@default:example.com',
+            databaseDsn: 'sqlite:///var/matrix.db',
+            bridge: $bridge,
+        );
+
+        $transport = $factory->create(new Dsn('smatrix://matrix.example.com'));
+        $message = new ChatMessage('Hello', new MatrixOptions('@john:example.com'));
+
+        $sentMessage = $transport->send($message);
+
+        $this->assertSame('bridge-result', $sentMessage->getMessageId());
+    }
+
+    public function testCreateThrowsWhenMissingPickleKey(): void
+    {
+        $factory = new MatrixTransportFactory(
+            pickleKey: null,
+            deviceId: 'DEVICE',
+            accessToken: 'config-token',
+            recoveryKey: 'recovery',
+            defaultRecipient: '@default:example.com',
+            databaseDsn: 'sqlite:///var/matrix.db',
+            bridge: $this->createMock(GolangLibBridge::class),
+        );
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The pickle key is not initialized');
+
+        $factory->create(new Dsn('smatrix://matrix.example.com'));
+    }
+
+    public function testCreateThrowsWhenMissingDeviceId(): void
+    {
+        $factory = new MatrixTransportFactory(
+            pickleKey: 'pickle',
+            deviceId: null,
+            accessToken: 'config-token',
+            recoveryKey: 'recovery',
+            defaultRecipient: '@default:example.com',
+            databaseDsn: 'sqlite:///var/matrix.db',
+            bridge: $this->createMock(GolangLibBridge::class),
+        );
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The device ID is not initialized');
+
+        $factory->create(new Dsn('smatrix://matrix.example.com'));
+    }
+
+    public function testCreateThrowsWhenMissingRecoveryKey(): void
+    {
+        $factory = new MatrixTransportFactory(
+            pickleKey: 'pickle',
+            deviceId: 'DEVICE',
+            accessToken: 'config-token',
+            recoveryKey: null,
+            defaultRecipient: '@default:example.com',
+            databaseDsn: 'sqlite:///var/matrix.db',
+            bridge: $this->createMock(GolangLibBridge::class),
+        );
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The recovery key is not initialized');
+
+        $factory->create(new Dsn('smatrix://matrix.example.com'));
+    }
+
+    public function testCreateThrowsWhenAccessTokenMissingEverywhere(): void
+    {
+        $factory = new MatrixTransportFactory(
+            pickleKey: 'pickle',
+            deviceId: 'DEVICE',
+            accessToken: null,
+            recoveryKey: 'recovery',
+            defaultRecipient: '@default:example.com',
+            databaseDsn: 'sqlite:///var/matrix.db',
+            bridge: $this->createMock(GolangLibBridge::class),
+        );
+
+        $this->expectException(MatrixException::class);
+        $this->expectExceptionMessage('The access token must be provided');
+
+        $factory->create(new Dsn('smatrix://matrix.example.com'));
+    }
+
+    public function testCreateThrowsOnUnsupportedScheme(): void
+    {
+        $factory = new MatrixTransportFactory(
+            pickleKey: 'pickle',
+            deviceId: 'DEVICE',
+            accessToken: 'config-token',
+            recoveryKey: 'recovery',
+            defaultRecipient: '@default:example.com',
+            databaseDsn: 'sqlite:///var/matrix.db',
+            bridge: $this->createMock(GolangLibBridge::class),
+        );
+
+        $this->expectException(UnsupportedSchemeException::class);
+
+        $factory->create(new Dsn('other://matrix.example.com'));
+    }
+}

--- a/tests/Transport/MatrixTransportTest.php
+++ b/tests/Transport/MatrixTransportTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rikudou\MatrixNotifier\Tests\Transport;
+
+use LogicException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Rikudou\MatrixNotifier\Bridge\BridgeMessage;
+use Rikudou\MatrixNotifier\Bridge\GolangLibBridge;
+use Rikudou\MatrixNotifier\Enum\MessageType;
+use Rikudou\MatrixNotifier\Enum\RenderingType;
+use Rikudou\MatrixNotifier\Exception\MatrixException;
+use Rikudou\MatrixNotifier\Options\MatrixOptions;
+use Rikudou\MatrixNotifier\Transport\MatrixTransport;
+use Symfony\Component\Notifier\Bridge\Matrix\MatrixOptions as SymfonyMatrixOptions;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\SmsMessage;
+
+#[CoversClass(MatrixTransport::class)]
+final class MatrixTransportTest extends TestCase
+{
+    public function testSendChatMessageWithMatrixOptions(): void
+    {
+        $bridge = $this->createMock(GolangLibBridge::class);
+        $bridge->expects($this->once())
+            ->method('send')
+            ->with($this->callback(function (BridgeMessage $message): bool {
+                $this->assertSame(MessageType::Notice, $message->messageType);
+                $this->assertSame(RenderingType::Html, $message->renderingType);
+                $this->assertSame('Hello Matrix', $message->message);
+                $this->assertSame('@john:example.com', $message->recipient);
+                $this->assertSame('sqlite:///var/matrix.db', $message->databaseDsn);
+                $this->assertSame('access-token', $message->accessToken);
+                $this->assertSame('recovery-key', $message->recoveryKey);
+                $this->assertSame('pickle-key', $message->pickleKey);
+                $this->assertSame('DEVICEID', $message->deviceId);
+                $this->assertSame('https://matrix.example.com:8448', $message->url);
+
+                return true;
+            }))
+            ->willReturn('$123');
+
+        $transport = new MatrixTransport(
+            accessToken: 'access-token',
+            recoveryKey: 'recovery-key',
+            pickleKey: 'pickle-key',
+            deviceId: 'DEVICEID',
+            databaseDsn: 'sqlite:///var/matrix.db',
+            bridge: $bridge,
+            defaultRecipient: '@default:example.com',
+        );
+        $transport->setHost('matrix.example.com');
+        $transport->setPort(8448);
+
+        $message = new ChatMessage('Hello Matrix', new MatrixOptions(
+            recipientId: '@john:example.com',
+            messageType: MessageType::Notice,
+            renderingType: RenderingType::Html,
+        ));
+
+        $sentMessage = $transport->send($message);
+
+        $this->assertSame('$123', $sentMessage->getMessageId());
+    }
+
+    public function testSendConvertsSymfonyMatrixOptions(): void
+    {
+        $bridge = $this->createMock(GolangLibBridge::class);
+        $bridge->expects($this->once())
+            ->method('send')
+            ->with($this->callback(function (BridgeMessage $message): bool {
+                $this->assertSame(MessageType::TextMessage, $message->messageType);
+                $this->assertSame(RenderingType::Html, $message->renderingType);
+                $this->assertSame('@alice:example.com', $message->recipient);
+
+                return true;
+            }))
+            ->willReturn('event-id');
+
+        $transport = new MatrixTransport(
+            accessToken: 'access-token',
+            recoveryKey: 'recovery-key',
+            pickleKey: 'pickle-key',
+            deviceId: 'DEVICEID',
+            databaseDsn: 'sqlite:///var/matrix.db',
+            bridge: $bridge,
+            defaultRecipient: '@default:example.com',
+        );
+
+        $message = new ChatMessage('Body', new SymfonyMatrixOptions([
+            'recipient_id' => '@alice:example.com',
+            'msgtype' => MessageType::TextMessage->value,
+            'format' => 'org.matrix.custom.html',
+        ]));
+
+        $sentMessage = $transport->send($message);
+
+        $this->assertSame('event-id', $sentMessage->getMessageId());
+    }
+
+    public function testSendThrowsOnUnsupportedMessageType(): void
+    {
+        $bridge = $this->createMock(GolangLibBridge::class);
+        $bridge->expects($this->never())->method('send');
+
+        $transport = new MatrixTransport(
+            accessToken: 'access-token',
+            recoveryKey: 'recovery-key',
+            pickleKey: 'pickle-key',
+            deviceId: 'DEVICEID',
+            databaseDsn: 'sqlite:///var/matrix.db',
+            bridge: $bridge,
+            defaultRecipient: '@default:example.com',
+        );
+
+        $message = new ChatMessage('Body', new SymfonyMatrixOptions([
+            'recipient_id' => '@alice:example.com',
+            'msgtype' => 'invalid-type',
+        ]));
+
+        $this->expectException(MatrixException::class);
+        $this->expectExceptionMessage('Unsupported message type: invalid-type');
+
+        $transport->send($message);
+    }
+
+    public function testSendThrowsWhenRecipientMissing(): void
+    {
+        $bridge = $this->createMock(GolangLibBridge::class);
+        $bridge->expects($this->never())->method('send');
+
+        $transport = new MatrixTransport(
+            accessToken: 'access-token',
+            recoveryKey: 'recovery-key',
+            pickleKey: 'pickle-key',
+            deviceId: 'DEVICEID',
+            databaseDsn: 'sqlite:///var/matrix.db',
+            bridge: $bridge,
+            defaultRecipient: '@default:example.com',
+        );
+
+        $message = new ChatMessage('Body', new MatrixOptions());
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Recipient id is required.');
+
+        $transport->send($message);
+    }
+
+    public function testSupportsOnlyMatrixChatMessages(): void
+    {
+        $bridge = $this->createMock(GolangLibBridge::class);
+
+        $transport = new MatrixTransport(
+            accessToken: 'access-token',
+            recoveryKey: 'recovery-key',
+            pickleKey: 'pickle-key',
+            deviceId: 'DEVICEID',
+            databaseDsn: 'sqlite:///var/matrix.db',
+            bridge: $bridge,
+            defaultRecipient: '@default:example.com',
+        );
+
+        $this->assertTrue($transport->supports(new ChatMessage('body', new MatrixOptions('@user:example.com'))));
+        $this->assertTrue($transport->supports(new ChatMessage('body')));
+        $this->assertFalse($transport->supports(new ChatMessage('body', new SymfonyMatrixOptions([]))));
+        $this->assertFalse($transport->supports(new SmsMessage('123', 'body')));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use DG\BypassFinals;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+BypassFinals::enable();


### PR DESCRIPTION
## Summary
- add PHPUnit tests covering matrix message options and transport factory behavior
- cover MatrixTransport scenarios including Symfony option conversion and validation
- enable mocking final classes in the test suite by installing dg/bypass-finals and updating the PHPUnit bootstrap

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d671222e88832eab08df9ba269d379