### PR TITLE
Add dependency injection configuration tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "symfony/console": "^7.3",
     "symfony/http-kernel": "^7.3",
     "symfony/dependency-injection": "^7.3",
-    "symfony/config": "^7.3"
+    "symfony/config": "^7.3",
+    "symfony/yaml": "^7.3"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "symfony/console": "^7.3",
     "symfony/http-kernel": "^7.3",
     "symfony/dependency-injection": "^7.3",
-    "symfony/config": "^7.3"
+    "symfony/config": "^7.3",
+    "symfony/yaml": "^7.3"
   },
   "autoload": {
     "psr-4": {
@@ -21,8 +22,7 @@
   "require-dev": {
     "symfony/matrix-notifier": "^7.3",
     "phpunit/phpunit": "^12.3",
-    "dg/bypass-finals": "^1.9",
-    "symfony/yaml": "^7.3"
+    "dg/bypass-finals": "^1.9"
   },
   "autoload-dev": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
     "symfony/console": "^7.3",
     "symfony/http-kernel": "^7.3",
     "symfony/dependency-injection": "^7.3",
-    "symfony/config": "^7.3",
-    "symfony/yaml": "^7.3"
+    "symfony/config": "^7.3"
   },
   "autoload": {
     "psr-4": {
@@ -22,7 +21,8 @@
   "require-dev": {
     "symfony/matrix-notifier": "^7.3",
     "phpunit/phpunit": "^12.3",
-    "dg/bypass-finals": "^1.9"
+    "dg/bypass-finals": "^1.9",
+    "symfony/yaml": "^7.3"
   },
   "autoload-dev": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "506e3a85602b25d3ca756e1cb0b40a31",
+    "content-hash": "0710b76d67207ca0be10abac37bf6987",
     "packages": [
         {
             "name": "psr/container",
@@ -1915,6 +1915,82 @@
                 }
             ],
             "time": "2025-08-18T13:10:53+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v7.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/d4f4a66866fe2451f61296924767280ab5732d9d",
+                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-27T11:34:33+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "97b6aff443fb9d95e27539123e3fe2d1",
+    "content-hash": "0710b76d67207ca0be10abac37bf6987",
     "packages": [
         {
             "name": "psr/container",
@@ -1915,6 +1915,82 @@
                 }
             ],
             "time": "2025-08-18T13:10:53+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v7.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/d4f4a66866fe2451f61296924767280ab5732d9d",
+                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-27T11:34:33+00:00"
         }
     ],
     "packages-dev": [
@@ -3919,82 +3995,6 @@
                 }
             ],
             "time": "2025-06-27T19:55:54+00:00"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v7.3.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/d4f4a66866fe2451f61296924767280ab5732d9d",
-                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "symfony/console": "<6.4"
-            },
-            "require-dev": {
-                "symfony/console": "^6.4|^7.0"
-            },
-            "bin": [
-                "Resources/bin/yaml-lint"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Loads and dumps YAML files",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.3.3"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-27T11:34:33+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0710b76d67207ca0be10abac37bf6987",
+    "content-hash": "97b6aff443fb9d95e27539123e3fe2d1",
     "packages": [
         {
             "name": "psr/container",
@@ -1915,82 +1915,6 @@
                 }
             ],
             "time": "2025-08-18T13:10:53+00:00"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v7.3.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/d4f4a66866fe2451f61296924767280ab5732d9d",
-                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "symfony/console": "<6.4"
-            },
-            "require-dev": {
-                "symfony/console": "^6.4|^7.0"
-            },
-            "bin": [
-                "Resources/bin/yaml-lint"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Loads and dumps YAML files",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.3.3"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-27T11:34:33+00:00"
         }
     ],
     "packages-dev": [
@@ -3995,6 +3919,82 @@
                 }
             ],
             "time": "2025-06-27T19:55:54+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v7.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/d4f4a66866fe2451f61296924767280ab5732d9d",
+                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-27T11:34:33+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rikudou\MatrixNotifier\Tests\DependencyInjection;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Rikudou\MatrixNotifier\DependencyInjection\Configuration;
+use Symfony\Component\Config\Definition\Processor;
+
+#[CoversClass(Configuration::class)]
+final class ConfigurationTest extends TestCase
+{
+    public function testDefaultConfiguration(): void
+    {
+        $processor = new Processor();
+
+        $config = $processor->processConfiguration(new Configuration(), []);
+
+        $this->assertSame('%kernel.project_dir%/var/matrix_notifier/matrix_internal.sqlite3', $config['database_dsn']);
+        $this->assertArrayHasKey('lib', $config);
+        $this->assertNull($config['lib']['library_path']);
+        $this->assertNull($config['lib']['headers_path']);
+        $this->assertArrayHasKey('default_recipient', $config);
+        $this->assertNull($config['default_recipient']);
+    }
+
+    public function testCustomConfigurationOverridesDefaults(): void
+    {
+        $processor = new Processor();
+
+        $config = $processor->processConfiguration(new Configuration(), [[
+            'database_dsn' => 'sqlite:///custom.sqlite3',
+            'pickle_key' => 'pickle',
+            'device_id' => 'DEVICEID',
+            'access_token' => 'access',
+            'recovery_key' => 'recovery',
+            'server_hostname' => 'matrix.example.com',
+            'default_recipient' => '@bot:example.com',
+            'lib' => [
+                'library_path' => '/opt/libmatrix.so',
+                'headers_path' => '/opt/libmatrix.h',
+            ],
+        ]]);
+
+        $this->assertSame('sqlite:///custom.sqlite3', $config['database_dsn']);
+        $this->assertSame('pickle', $config['pickle_key']);
+        $this->assertSame('DEVICEID', $config['device_id']);
+        $this->assertSame('access', $config['access_token']);
+        $this->assertSame('recovery', $config['recovery_key']);
+        $this->assertSame('matrix.example.com', $config['server_hostname']);
+        $this->assertSame('@bot:example.com', $config['default_recipient']);
+        $this->assertSame('/opt/libmatrix.so', $config['lib']['library_path']);
+        $this->assertSame('/opt/libmatrix.h', $config['lib']['headers_path']);
+    }
+}

--- a/tests/DependencyInjection/RikudouMatrixNotifierExtensionTest.php
+++ b/tests/DependencyInjection/RikudouMatrixNotifierExtensionTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rikudou\MatrixNotifier\Tests\DependencyInjection;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Rikudou\MatrixNotifier\DependencyInjection\RikudouMatrixNotifierExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+#[CoversClass(RikudouMatrixNotifierExtension::class)]
+final class RikudouMatrixNotifierExtensionTest extends TestCase
+{
+    public function testLoadRegistersDefaultParameters(): void
+    {
+        $container = new ContainerBuilder();
+
+        $extension = new RikudouMatrixNotifierExtension();
+        $extension->load([], $container);
+
+        $this->assertSame(
+            '%kernel.project_dir%/var/matrix_notifier/matrix_internal.sqlite3',
+            $container->getParameter('rikudou.internal.matrix.database_dsn'),
+        );
+        $this->assertNull($container->getParameter('rikudou.internal.matrix.pickle_key'));
+        $this->assertNull($container->getParameter('rikudou.internal.matrix.device_id'));
+        $this->assertNull($container->getParameter('rikudou.internal.matrix.access_token'));
+        $this->assertNull($container->getParameter('rikudou.internal.matrix.recovery_key'));
+        $this->assertNull($container->getParameter('rikudou.matrix_notifier.server_hostname'));
+        $this->assertNull($container->getParameter('rikudou.matrix_notifier.server_url'));
+        $this->assertNull($container->getParameter('rikudou.internal.matrix.lib_path'));
+        $this->assertNull($container->getParameter('rikudou.internal.matrix.headers_path'));
+        $this->assertNull($container->getParameter('rikudou.internal.matrix.default_recipient'));
+    }
+
+    public function testLoadRegistersCustomParameters(): void
+    {
+        $container = new ContainerBuilder();
+
+        $extension = new RikudouMatrixNotifierExtension();
+        $extension->load([
+            [
+                'database_dsn' => 'sqlite:///custom.sqlite3',
+                'pickle_key' => 'pickle',
+                'device_id' => 'DEVICE',
+                'access_token' => 'token',
+                'recovery_key' => 'recovery',
+                'server_hostname' => 'matrix.example.com',
+                'default_recipient' => '@bot:example.com',
+                'lib' => [
+                    'library_path' => '/opt/libmatrix.so',
+                    'headers_path' => '/opt/libmatrix.h',
+                ],
+            ],
+        ], $container);
+
+        $this->assertSame('sqlite:///custom.sqlite3', $container->getParameter('rikudou.internal.matrix.database_dsn'));
+        $this->assertSame('pickle', $container->getParameter('rikudou.internal.matrix.pickle_key'));
+        $this->assertSame('DEVICE', $container->getParameter('rikudou.internal.matrix.device_id'));
+        $this->assertSame('token', $container->getParameter('rikudou.internal.matrix.access_token'));
+        $this->assertSame('recovery', $container->getParameter('rikudou.internal.matrix.recovery_key'));
+        $this->assertSame('matrix.example.com', $container->getParameter('rikudou.matrix_notifier.server_hostname'));
+        $this->assertSame('https://matrix.example.com', $container->getParameter('rikudou.matrix_notifier.server_url'));
+        $this->assertSame('/opt/libmatrix.so', $container->getParameter('rikudou.internal.matrix.lib_path'));
+        $this->assertSame('/opt/libmatrix.h', $container->getParameter('rikudou.internal.matrix.headers_path'));
+        $this->assertSame('@bot:example.com', $container->getParameter('rikudou.internal.matrix.default_recipient'));
+    }
+}


### PR DESCRIPTION
## Summary
- add coverage for the configuration tree defaults and overrides
- ensure the bundle extension registers container parameters as expected
- require the Symfony YAML component so the extension can load its service definitions during tests

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d67f594200832e95cef4873921c1e3