### PR TITLE
Add additional PHP unit tests

### DIFF
--- a/tests/Options/MatrixOptionsTest.php
+++ b/tests/Options/MatrixOptionsTest.php
@@ -31,6 +31,24 @@ final class MatrixOptionsTest extends TestCase
         );
     }
 
+    public function testDefaultValuesAreUsedWhenNotExplicitlyProvided(): void
+    {
+        $options = new MatrixOptions();
+
+        $this->assertNull($options->getRecipientId());
+        $this->assertSame(MessageType::TextMessage, $options->messageType);
+        $this->assertSame(RenderingType::PlainText, $options->renderingType);
+
+        $this->assertSame(
+            [
+                'recipientId' => null,
+                'messageType' => MessageType::TextMessage->value,
+                'renderingType' => RenderingType::PlainText->value,
+            ],
+            $options->toArray(),
+        );
+    }
+
     public function testGetRecipientIdReturnsConfiguredValue(): void
     {
         $options = new MatrixOptions(recipientId: '@alice:example.com');


### PR DESCRIPTION
## Summary
- add coverage for MatrixOptions defaults
- expand MatrixTransport tests to cover default conversions and error handling
- ensure MatrixTransportFactory favors DSN-provided access tokens during send

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d682382390832eb5e7d8ae9884031e