### PR TITLE
Fix PHPUnit coverage execution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,10 @@
     "phpunit/phpunit": "^12.3",
     "dg/bypass-finals": "^1.9"
   },
+  "scripts": {
+    "test": "vendor/bin/phpunit",
+    "coverage": "php -d xdebug.mode=coverage vendor/bin/phpunit --coverage-text"
+  },
   "autoload-dev": {
     "psr-4": {
       "Rikudou\\MatrixNotifier\\Tests\\": "tests/"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,15 +3,17 @@
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.3/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
          colors="true"
+         cacheDirectory=".phpunit.cache"
 >
-    <coverage cacheDirectory=".phpunit.cache/code-coverage">
+    <coverage/>
+    <source>
         <include>
             <directory suffix=".php">src</directory>
         </include>
         <exclude>
             <directory suffix=".php">tests</directory>
         </exclude>
-    </coverage>
+    </source>
     <testsuites>
         <testsuite name="SecureMatrixNotifierBundle Test Suite">
             <directory>tests</directory>


### PR DESCRIPTION
## Summary
- update the PHPUnit configuration to use the current schema for source inclusion and cache handling so coverage is processed
- add Composer scripts that expose plain test execution and a coverage-friendly command that enables Xdebug coverage mode automatically

## Testing
- composer coverage

------
https://chatgpt.com/codex/tasks/task_e_68d685d5e76c832eb9b1d4b3452e3f81