### PR TITLE
Enable coverage report in CI

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           php-version: '8.4'
           extensions: ffi
-          coverage: none
+          coverage: xdebug
       - name: Validate composer.json
         run: composer validate --no-interaction --no-check-publish
       - name: Install dependencies
         run: composer install --no-interaction --no-progress --prefer-dist
-      - name: Run PHPUnit
-        run: vendor/bin/phpunit
+      - name: Run PHPUnit with coverage
+        run: composer coverage


### PR DESCRIPTION
## Summary
- enable Xdebug coverage support in the PHPUnit workflow
- run the existing Composer coverage script during CI to print coverage results

## Testing
- not run (CI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d68870bf18832e95aa7e0d39765864